### PR TITLE
Make valid web extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "*"
   ],
   "main": "./out/extension.js",
+  "browser": "./out/extension.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/Arkaedan/vscode-epsilon.git"


### PR DESCRIPTION
Fix for issue #3. Tested locally using `npx @vscode/test-web --extensionDevelopmentPath=$extensionFolderPath $testDataPath` and on vscode.dev following the instructions [here](https://code.visualstudio.com/api/extension-guides/web-extensions#test-your-web-extension-in-on-vscode.dev).