### PR TITLE
Build language server from CI (fixes #12)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+on:
+  push:
+    branches:
+  pull_request:
+    branches:
+      - main
+
+name: Build Extension
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 16
+          cache: "npm"
+      - name: Set up JDK 11 for x64
+        uses: actions/setup-java@v4
+        with:
+          java-version: "11"
+          distribution: "temurin"
+          cache: maven
+      - name: Build the Language Server
+        run: cd language-server && mvn --batch-mode --update-snapshots package
+      - name: Install Node dependencies
+        run: npm ci
+      - name: Build the extension
+        run: npm run compile
+      - name: Package the extension
+        run: npm install -g @vscode/vsce && vsce package
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: built-extension
+          path: "*.vsix"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,18 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
+      - name: Set up JDK 11 for x64
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build the Language Server
+        run: cd language-server && mvn --batch-mode --update-snapshots package
       - run: npm ci
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v1

--- a/language-server/.gitignore
+++ b/language-server/.gitignore
@@ -1,2 +1,1 @@
-target/**
-!target/language-server.jar
+target/


### PR DESCRIPTION
This pull request is meant to fix #12, by having the language server built from Github Actions. It also adds a new workflow which runs on every push / pull request, which only builds the .vsix locally and uploads it as a build artifact, to help detect day-to-day issues and make it easier for people to try out interim versions.