### PR TITLE
Add remote debugging via DAP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/vscode": "^1.50.0",
         "@typescript-eslint/eslint-plugin": "^4.1.1",
         "@typescript-eslint/parser": "^4.1.1",
+        "@vscode/debugprotocol": "^1.65.0",
         "@vscode/test-electron": "^2.3.9",
         "@vscode/test-web": "^0.0.51",
         "esbuild": "^0.19.5",
@@ -818,6 +819,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "node_modules/@vscode/debugprotocol": {
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.65.0.tgz",
+      "integrity": "sha512-ejerrPMBXzYms6Ks+Gb7cdXtdncmT0xwIKNsc0c/SxhEa0HVY5jdvLUegYE91p7CQJpCnXOD/r2CvViN8txLLA==",
       "dev": true
     },
     "node_modules/@vscode/test-electron": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,20 @@
     "type": "git",
     "url": "https://github.com/Arkaedan/vscode-epsilon.git"
   },
+  "activationEvents": [
+    "workspaceContains:**/*.eol",
+    "workspaceContains:**/*.ecl",
+    "workspaceContains:**/*.egl",
+    "workspaceContains:**/*.egx",
+    "workspaceContains:**/*.evl",
+    "workspaceContains:**/*.etl",
+    "workspaceContains:**/*.eml",
+    "workspaceContains:**/*.epl",
+    "workspaceContains:**/*.mig",
+    "workspaceContains:**/*.pinset",
+    "workspaceContains:**/*.emf",
+    "workspaceContains:**/*.flexmi"
+  ],
   "contributes": {
     "languages": [
       {
@@ -324,7 +338,110 @@
           "default": false
         }
       }
-    }
+    },
+    "breakpoints": [
+      {
+        "language": "eol"
+      },
+      {
+        "language": "ecl"
+      },
+      {
+        "language": "egl"
+      },
+      {
+        "language": "egx"
+      },
+      {
+        "language": "evl"
+      },
+      {
+        "language": "etl"
+      },
+      {
+        "language": "eml"
+      },
+      {
+        "language": "epl"
+      },
+      {
+        "language": "flock"
+      },
+      {
+        "language": "pinset"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "epsilon",
+        "languages": [
+          "eol",
+          "ecl",
+          "egl",
+          "egx",
+          "evl",
+          "etl",
+          "eml",
+          "epl",
+          "flock",
+          "pinset"
+        ],
+        "label": "Epsilon Debug",
+        "configurationAttributes": {
+          "attach": {
+            "required": [
+              "port"
+            ],
+            "properties": {
+              "port": {
+                "type": "integer",
+                "description": "Port to connect to"
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "type": "epsilon",
+            "request": "attach",
+            "name": "Attach to Epsilon script",
+            "port": 4040
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "Epsilon: Attach",
+            "description": "A new configuration for attaching to a running Epsilon script.",
+            "body": {
+              "type": "epsilon",
+              "request": "attach",
+              "name": "Attach to Epsilon script",
+              "port": 4040
+            }
+          }
+        ]
+      }
+    ],
+    "problemMatchers": [
+      {
+        "owner": "epsilon-debug",
+        "name": "epsilon-debug",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}"
+        ],
+        "pattern": {
+          "regexp": "^.*(FAILURE):\\s*(.*)$",
+          "severity": 1,
+          "message": 2
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "Started Epsilon debug server"
+        }
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -348,6 +465,7 @@
     "@types/vscode": "^1.50.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
+    "@vscode/debugprotocol": "^1.65.0",
     "esbuild": "^0.19.5",
     "eslint": "^7.9.0",
     "glob": "^7.1.6",

--- a/src/main/debug-client.ts
+++ b/src/main/debug-client.ts
@@ -1,0 +1,21 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+	context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory(
+        'epsilon', new EpsilonDebugAdapterServerDescriptorFactory()));
+}
+
+export function deactivate() {
+	// nothing to do
+}
+
+class EpsilonDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+
+	createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+		let port = 'port' in session.configuration ? session.configuration['port'] : 4040;
+		return new vscode.DebugAdapterServer(port);
+	}
+
+}

--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -3,9 +3,11 @@ import * as vscode from "vscode";
 import { registerTerminalLinkProvider } from "../common/terminal-link-provider";
 import { registerTemplateHelperCommands } from "../common/template-helpers";
 import * as lspClient from "../main/lsp-client";
+import * as debugClient from "../main/debug-client";
 
 export function activate(context: vscode.ExtensionContext) {
   lspClient.activate(context);
+  debugClient.activate(context);
   registerTerminalLinkProvider(context);
   registerTemplateHelperCommands(context);
 }
@@ -13,4 +15,5 @@ export function activate(context: vscode.ExtensionContext) {
 // this method is called when your extension is deactivated
 export function deactivate() {
   lspClient.deactivate();
+  debugClient.deactivate();
 }


### PR DESCRIPTION
This commit adds the minimal code needed to have VS Code attach to a running Epsilon debug adapter over TCP (available from [Epsilon 2.6.0](https://github.com/eclipse/epsilon/pull/92)). The approach is to have the Ant tasks start the server and wait for VS Code to attach to them before starting the Epsilon script to be debugged.

This only requires using a DebugAdapterDescriptorFactory that looks at the "port" in the launch.json entry being executed, and passes that on to the standard DebugAdapterServer class. All the debugging complexity will be hidden behind the DAP server.