### PR TITLE
Add support for the new 'stop at every statement' option

### DIFF
--- a/language-server/pom.xml
+++ b/language-server/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>org.eclipse.emfatic</groupId>
       <artifactId>org.eclipse.emfatic.core</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.0</version>
     </dependency>    
     <dependency>
       <groupId>org.jcommander</groupId>

--- a/package.json
+++ b/package.json
@@ -396,6 +396,11 @@
               "port": {
                 "type": "integer",
                 "description": "Port to connect to"
+              },
+              "stop-at-every-statement": {
+                "type": "boolean",
+                "description": "If true, line breakpoints will stop at every statement on their line.",
+                "default": false
               }
             }
           }


### PR DESCRIPTION
We have just added an option to the debug adapter to make it stop at every statement on a line breakpoint. This is a workaround for the fact that LSP4E does not support inline breakpoints at the moment, but it could also have its uses for people debugging from VS Code.

To use this option, you'd specify it from the `launch.json` file, like this:

```json
{
  "type": "epsilon",
  "request": "attach",
  "name": "Debug 01-hello",
  "port": 4040,
  "stop-at-every-statement": true
}
```