### PR TITLE
Add support for the Epsilon Model Generation language

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,8 @@
           "epl"
         ],
         "extensions": [
-          ".epl"
+          ".epl",
+          ".emg"
         ],
         "icon": {
           "light": "./images/light/epl.svg",


### PR DESCRIPTION
The Epsilon Model Generation language is an application of EPL that uses annotations to automatically generate models:

  https://eclipse.dev/epsilon/doc/emg/

We can just reuse our EPL support for it: this makes for a very succint PR :-).